### PR TITLE
fix: fix broken links and 404 errors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -78,6 +78,9 @@ autopages:
       - "tag_page.html"
     title: ":tag" # :tag is replaced by the tag name
     permalink: "/tag/:tag"
+    slugify:
+      mode: "pretty"
+      case: false
 
 feed:
   collections:

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -20,7 +20,7 @@
     {% assign tags = site.tags | sort %}
     {% for tag in tags %}
     <span class="site-tag">
-      <a href="/tag/{{ tag | first | slugify }}/" style="font-size: {{ tag | last | size  |  times: 4 | plus: 80  }}%">
+      <a href="/tag/{{ tag | first }}/" style="font-size: {{ tag | last | size  |  times: 4 | plus: 80  }}%">
         {{ tag[0] | replace:'-', ' ' }} ({{ tag | last | size }})
       </a>
     </span>

--- a/_layouts/tag_page.html
+++ b/_layouts/tag_page.html
@@ -26,7 +26,7 @@ pagination:
           <article class="blog-post blog-spacing wow fadeIn" data-wow-duration="1s">
             {% if post.post_image %}
             <div class="blog-img">
-              <a href="single.html"><img src="{{post.post_image}}" alt="{{post.title}}" /></a>
+              <a href="{{post.url}}"><img src="{{post.post_image}}" alt="{{post.title}}" /></a>
             </div>
             {% endif %}
             <div class="blog-content">

--- a/_posts/2016-06-06-why-hospitalrun.md
+++ b/_posts/2016-06-06-why-hospitalrun.md
@@ -202,7 +202,7 @@ holds a tremendous opportunity to partner the NGO, government, and tech sectors 
 
 It's almost as if, by <b>working together</b>... we just might have a fighting chance of changing the world.
 
-Moreover, through initiatives like our [Hack Day](/lisbon) events, we're seeing tremendous opportunity to engage those with programming, design, devops, project management, and marketing backgrounds to use their true gifts in service to a cause that has utility, opportunity, and innovative technology.
+Moreover, through initiatives like our Hack Day events, we're seeing tremendous opportunity to engage those with programming, design, devops, project management, and marketing backgrounds to use their true gifts in service to a cause that has utility, opportunity, and innovative technology.
 
 # Now what?
 

--- a/_posts/2018-02-26-roadmap-to-hospitalrun-1.0.markdown
+++ b/_posts/2018-02-26-roadmap-to-hospitalrun-1.0.markdown
@@ -13,7 +13,7 @@ layout: post
 excerpt: Back in May of 2017, we announced that HospitalRun 1.0 was available in beta.
 ---
 
-Back in May of 2017, we announced that <a href="/blog/2017/05/announcing-hospitalrun-1.0.0-beta" target="hr2">HospitalRun 1.0 was available in beta</a>. Since then, we've had thousands of downloads of the <a href="/tryit" target="hr2">Electron app</a> and thousands more deploy the Docker image. There's been good and bad feedback, and throughout all of that, the entire original core team has undergone huge transitions in our day jobs (as in 2 of the 3 of us changed jobs), which has hampered the pace the project.
+Back in May of 2017, we announced that <a href="/blog/announcing-hospitalrun-1.0.0-beta" target="hr2">HospitalRun 1.0 was available in beta</a>. Since then, we've had thousands of downloads of the <a href="/tryit" target="hr2">Electron app</a> and thousands more deploy the Docker image. There's been good and bad feedback, and throughout all of that, the entire original core team has undergone huge transitions in our day jobs (as in 2 of the 3 of us changed jobs), which has hampered the pace the project.
 
 # Determining the 1.0 Feature Set
 

--- a/_posts/2019-08-07-a-new-beginning copy.md
+++ b/_posts/2019-08-07-a-new-beginning copy.md
@@ -13,7 +13,7 @@ author_bio: Software and Cloud Architect. DevOps philosophy lover. Container ent
 excerpt: I am Maksim Sinik and I am very excited and honoured to announce that I am the new Lead Maintainer of the HospitalRun project.
 ---
 
-Hi! First of all, let me introduce myself: I am Maksim Sinik and I am very excited and honoured to announce that I am the new Lead Maintainer of the HospitalRun project. My interest in HR started some time ago when I read [this](https://hospitalrun.io/blog/2018/07/help-wanted-a-message-from-the-co-founders) post: I immediately thought that such a amazing project should not be abandoned and that all the efforts of hundreds of contributors should not be in vain!
+Hi! First of all, let me introduce myself: I am Maksim Sinik and I am very excited and honoured to announce that I am the new Lead Maintainer of the HospitalRun project. My interest in HR started some time ago when I read [this](https://hospitalrun.io/blog/help-wanted-a-message-from-the-co-founders) post: I immediately thought that such a amazing project should not be abandoned and that all the efforts of hundreds of contributors should not be in vain!
 
 I contacted Joel and after an intense chat we agreed that I would take over the management of HospitalRun. We discussed about the major issues and what the direction of the project should be. We both agreed that the codebase is old and difficult to contribute to for the today's standards. Unfortunately we had to make a hard decision, but I'm sure that it will pay in terms of contributions and future features: a complete rewrite of HR to adapt it to the modern cloud world.
 


### PR DESCRIPTION
Fixes #105 

**Summary:**

- Remove nonexisting broken link: `Hack Day(/lisbon)` from Why Hospitalrun blog post
- Set post image link to be `post.url` instead of nonexistent `/single.html`
- Fix blog broken links to match the correct links
- Do slugify in tag page config to fix broken tag links (V1.0.0, V2.0.0)